### PR TITLE
Fix build issue on new versions of ReactNative

### DIFF
--- a/android/src/main/java/com/galmis/rnbugfender/RNBugfenderPackage.java
+++ b/android/src/main/java/com/galmis/rnbugfender/RNBugfenderPackage.java
@@ -24,7 +24,7 @@ public class RNBugfenderPackage implements ReactPackage {
     return modules;
   }
 
-  @Override
+  // Deprecated
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
`createJSModules` no longers exists as of ReactNative 0.47 (current version is 0.54.2)

See e.g. https://github.com/oblador/react-native-vector-icons/pull/516/files